### PR TITLE
Change dialogue schema to include user access details

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -749,7 +749,9 @@ Projects
          "url": "/projects/23/dialogues/21",
          "is_archived": false,
          "is_published": false,
-         "has_changes": false
+         "has_changes": false,
+         "can_view": true,
+         "can_edit": true
        }]
      }
 
@@ -1033,7 +1035,9 @@ If the dialogue isn't found, a ``404`` response will be given. The response body
       "sequences": [],
       "is_archived": false,
       "is_published": false,
-      "has_changes": false
+      "has_changes": false,
+       "can_view": true,
+       "can_edit": true
     }
 
 .. warning::
@@ -1086,7 +1090,9 @@ If the dialogue isn't found, a ``404`` response will be given. The response body
      }],
      "is_archived": false,
      "is_published": false,
-     "has_changes": false
+     "has_changes": false,
+     "can_view": true,
+     "can_edit": true
    }
 
 .. warning::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -830,7 +830,9 @@ If the project isn't found, a ``404`` response will be given. The response body'
          "url": "/projects/23/dialogues/21",
          "is_archived": false,
          "is_published": false,
-         "has_changes": false
+         "has_changes": false,
+         "can_view": true,
+         "can_edit": true
        }]
      }
 
@@ -867,7 +869,9 @@ If the project isn't found, a ``404`` response will be given. The response body'
        "url": "/projects/23/dialogues/21",
        "is_archived": false,
        "is_published": false,
-       "has_changes": false
+       "has_changes": false,
+       "can_view": true,
+       "can_edit": true
      }]
    }
 
@@ -898,17 +902,26 @@ Dialogues
        "url": "/projects/23/dialogues/21",
        "is_archived": false,
        "is_published": false,
-       "has_changes": false
+       "has_changes": false,
+       "can_view": true,
+       "can_edit": true
      }]
 
   :query boolean is_archived:
-    If ``false``, only return unarchived dialogues. If ``true``, only return archived dialogues. If omitted, both archived and unarchived dialogues are retrieved.
+    Filter on whether this dialogue has been archived.
 
   :query boolean is_published:
-    If ``false``, only return unpublished dialogues. If ``true``, only return published dialogues. If omitted, both published and unpublished dialogues are retrieved.
+    Filter on whether this dialogue has been published.
 
   :query boolean has_changes:
-    If ``false``, only return dialogues without unpublished changes. If ``true``, only return dialogues with unpublished changes. If omitted, dialogues with published and unpublished changes are retrieved.
+    Filter on whether this dialogue has unpublished changes or not.
+
+  :query boolean can_view:
+    Filter on whether the user can view this dialogue or not.
+
+  :query boolean can_edit:
+    Filter on whether the user can edit this dialogue or not.
+
 
 .. http:get:: /projects/(str:project_id)/dialogues/(str:dialogue_id)
 
@@ -929,7 +942,9 @@ Retrieves the :ref:`description <data-dialogues>` of the dialogue with id ``dial
        "sequences": [],
        "is_archived": false,
        "is_published": false,
-       "has_changes": false
+       "has_changes": false,
+       "can_view": true,
+       "can_edit": true
      }
 
 If the dialogue isn't found, a ``404`` response will be given. The response body's ``details`` object contains the ``id`` given in the request.
@@ -974,7 +989,9 @@ If the dialogue isn't found, a ``404`` response will be given. The response body
        "sequences": [],
        "is_archived": false,
        "is_published": false,
-       "has_changes": false
+       "has_changes": false,
+       "can_view": true,
+       "can_edit": true
      }
 
 .. _dialogues-put:

--- a/schemas/dialogue/dialogue.yml
+++ b/schemas/dialogue/dialogue.yml
@@ -51,4 +51,16 @@ properties:
     description: |
       Flag representing whether this dialogue has unpublished changes.
 
+  can_view:
+    type: boolean
+    readOnly: true
+    description: |
+      Flag representing whether the authenticated user can view this dialogue.
+
+  can_edit:
+    type: boolean
+    readOnly: true
+    description: |
+      Flag representing whether the authenticated user can edit this dialogue.
+
 additionalProperties: false

--- a/schemas/dialogue/summary.yml
+++ b/schemas/dialogue/summary.yml
@@ -41,4 +41,16 @@ properties:
     description: |
       Flag representing whether this dialogue has unpublished changes.
 
+  can_view:
+    type: boolean
+    readOnly: true
+    description: |
+      Flag representing whether the authenticated user can view this dialogue.
+
+  can_edit:
+    type: boolean
+    readOnly: true
+    description: |
+      Flag representing whether the authenticated user can edit this dialogue.
+
 additionalProperties: false


### PR DESCRIPTION
We need to include read only properties in the current dialogue schema for whether a user can view or edit a dialogue.
