### PR TITLE
Unwrap data from auth api result objects

### DIFF
--- a/src/api/permissions.js
+++ b/src/api/permissions.js
@@ -6,12 +6,14 @@ const authApi = require('src/auth');
 
 function create(teamId, d, {auth, namespace = configNamespace}) {
   d = conj(d, {namespace});
-  return authApi.teams.addPermission(teamId, d, {conf: authConf(auth)});
+  return authApi.teams.addPermission(teamId, d, {conf: authConf(auth)})
+    .then(({data}) => data);
 }
 
 
 function remove(teamId, id, {auth}) {
-  return authApi.teams.removePermission(teamId, id, {conf: authConf(auth)});
+  return authApi.teams.removePermission(teamId, id, {conf: authConf(auth)})
+    .then(({data}) => data);
 }
 
 

--- a/src/api/teams.js
+++ b/src/api/teams.js
@@ -4,13 +4,15 @@ const authApi = require('src/auth');
 
 function list(organizationId, {auth}) {
   return authApi.organizations.listTeams(organizationId, {
-    conf: authConf(auth)
-  });
+      conf: authConf(auth)
+    })
+    .then(({data}) => data);
 }
 
 
 function get(id, {auth}) {
-  return authApi.teams.get(id, {conf: authConf(auth)});
+  return authApi.teams.get(id, {conf: authConf(auth)})
+    .then(({data}) => data);
 }
 
 

--- a/src/contexts/permission.js
+++ b/src/contexts/permission.js
@@ -17,7 +17,7 @@ function createAccess(teamId, permission) {
 
 function removeAccess(teamId, id, {auth}) {
   return authApi.teams.get(teamId, {conf: authConf(auth)})
-    .then(({permissions}) => find(permissions, {id}))
+    .then(({data: {permissions}}) => find(permissions, {id}))
     .then(access)
     .then(effect(v => {
       if (isNull(v)) throw new AuthorizationError();

--- a/tests/api/permissions.test.js
+++ b/tests/api/permissions.test.js
@@ -15,7 +15,7 @@ describe('api.permissions', () => {
   });
 
   describe('create', () => {
-    it('should create permissions', () => {
+    it('should create the given permission', () => {
       const expected = {
         id: 22,
         type: 'project:write',
@@ -36,22 +36,21 @@ describe('api.permissions', () => {
         }, {
           conf: authConf(auth)
         })
-        .returns(expected);
+        .returns(Promise.resolve({data: expected}));
 
-      const res = permissions.create(23, {
-        type: 'project:write',
-        object_id: 21
-      }, {
-        namespace: '_numi_',
-        auth
-      });
-
-      expect(res).to.deep.equal(expected);
+      return permissions.create(23, {
+          type: 'project:write',
+          object_id: 21
+        }, {
+          namespace: '_numi_',
+          auth
+        })
+        .then(res => expect(res).to.deep.equal(expected));
     });
   });
 
   describe('remove', () => {
-    it('should throw a NotImplementedError', () => {
+    it('should remove the given permission', () => {
       const expected = {
         id: 22,
         type: 'project:write',
@@ -66,10 +65,10 @@ describe('api.permissions', () => {
 
       this.sandbox.stub(authApi.teams, 'removePermission')
         .withArgs(23, 21, {conf: authConf(auth)})
-        .returns(expected);
+        .returns(Promise.resolve({data: expected}));
 
-      const res = permissions.remove(23, 21, {auth});
-      expect(res).to.deep.equal(expected);
+      return permissions.remove(23, 21, {auth})
+        .then(res => expect(res).to.deep.equal(expected));
     });
   });
 });

--- a/tests/api/teams.test.js
+++ b/tests/api/teams.test.js
@@ -28,7 +28,7 @@ describe('api.teams', () => {
 
       this.sandbox.stub(authApi.organizations, 'listTeams')
         .withArgs(23, {conf: authConf(auth)})
-        .returns(Promise.resolve(expected));
+        .returns(Promise.resolve({data: expected}));
 
       return teams.list(23, {auth})
         .then(res => expect(res).to.deep.equal(expected));
@@ -46,7 +46,7 @@ describe('api.teams', () => {
 
       this.sandbox.stub(authApi.teams, 'get')
         .withArgs(21, {conf: authConf(auth)})
-        .returns(Promise.resolve(expected));
+        .returns(Promise.resolve({data: expected}));
 
       return teams.get(21, {auth})
         .then(res => expect(res).to.deep.equal(expected));

--- a/tests/contexts/permission.test.js
+++ b/tests/contexts/permission.test.js
@@ -78,19 +78,21 @@ describe('contexts.permission', () => {
       this.sandbox.stub(authApi.teams, 'get')
         .withArgs(7, {conf: authConf(auth)})
         .returns(Promise.resolve({
-          permissions: [{
-            id: 1,
-            type: 'project:admin',
-            object_id: 23
-          }, {
-            id: 2,
-            type: 'project:read',
-            object_id: 23
-          }, {
-            id: 3,
-            type: 'project:write',
-            object_id: 23
-          }]
+          data: {
+            permissions: [{
+              id: 1,
+              type: 'project:admin',
+              object_id: 23
+            }, {
+              id: 2,
+              type: 'project:read',
+              object_id: 23
+            }, {
+              id: 3,
+              type: 'project:write',
+              object_id: 23
+            }]
+          }
         }));
 
         return Promise.all([1, 2, 3]
@@ -119,11 +121,13 @@ describe('contexts.permission', () => {
       this.sandbox.stub(authApi.teams, 'get')
         .withArgs(7, {conf: authConf(auth)})
         .returns(Promise.resolve({
-          permissions: [{
-            id: 1,
-            type: 'unsupported',
-            object_id: 23
-          }]
+          data: {
+            permissions: [{
+              id: 1,
+              type: 'unsupported',
+              object_id: 23
+            }]
+          }
         }));
 
         return permission.removeAccess(7, 1, {auth})


### PR DESCRIPTION
At the moment we just return the api result objects.
